### PR TITLE
fix: textarea style not applying to textarea element

### DIFF
--- a/components/Form/Chatbot.vue
+++ b/components/Form/Chatbot.vue
@@ -7,7 +7,7 @@
         autofocus
         required />
 
-    <textarea :placeholder="$t('DESCRIPTION_PLACEHOLDER')"
+    <textarea class="textarea" :placeholder="$t('DESCRIPTION_PLACEHOLDER')"
         v-model="description" rows="4"></textarea>
 
     <div class="p-3 bg-neutral-100 text-center font-semibold text-brand_primary" v-if="error">

--- a/components/Form/ChatbotQuestion.vue
+++ b/components/Form/ChatbotQuestion.vue
@@ -8,7 +8,7 @@
         autofocus
         required />
 
-    <textarea :placeholder="$t('ANSWER_PLACEHOLDER')"
+    <textarea class="textarea" :placeholder="$t('ANSWER_PLACEHOLDER')"
         v-model="answer" rows="7"></textarea>
 
     <div class="p-3 bg-neutral-100 text-center font-semibold text-brand_primary" v-if="error">


### PR DESCRIPTION
Aggiunge la classe `textarea` alle due textarea nel chatbot e nelle Q&A. Da capire come mai il selettore css non applica lo stile direttamente all'elemento `textarea`