### PR TITLE
fix: scrollbar disappearing on modal opening

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -29,11 +29,11 @@ modalStore.$onAction(({
     onError, // hook if the action throws or rejects
 }) => {
     after(() => {
-        useHead({
-            bodyAttrs: {
-                class: store.activeModal ? 'overflow-hidden' : '',
-            }
-        });
+        if(store.activeModal) {
+            document.body.classList.add('overflow-hidden');
+        } else {
+            document.body.classList.remove('overflow-hidden');
+        }
     });
 });
 


### PR DESCRIPTION
Rimette visibile la scrollbar dopo la chiusura della modale. Il problema era causato da `useHead`:
```
useHead({
    bodyAttrs: {
        class: store.activeModal ? 'overflow-hidden' : '',
    }
});
```
**Aggiungeva** la classe `overflow-hidden` in caso che `store.activeModal` non fosse `null` ma in caso contrario **aggiungeva** una classe vuota senza rimuovere  `overflow-hidden`

Rif: https://trello.com/c/D8idkh61/189-scrollbar-scompare-nella-chat