### PR TITLE
Fix: infinite loaders on new/delete item

### DIFF
--- a/components/Element/ChatbotFiles.vue
+++ b/components/Element/ChatbotFiles.vue
@@ -60,6 +60,7 @@ const loadFiles = async () => {
     files.value = items.data;
     indexedItems = await $fetch(`/api/brevia/index/${collection?.uuid}/documents_metadata?filter[type]=files`);
   }
+  setTimeout(() => (isLoading.value = false), 750);
 };
 
 await loadFiles();

--- a/components/Element/ChatbotLinks.vue
+++ b/components/Element/ChatbotLinks.vue
@@ -82,6 +82,7 @@ const loadLinks = async () => {
     links.value = items.data;
     indexedItems = await $fetch(`/api/brevia/index/${collection?.uuid}/documents_metadata?filter[type]=links`);
   }
+  setTimeout(() => (isLoading.value = false), 750);
 };
 
 await loadLinks();

--- a/components/Element/ChatbotQuestions.vue
+++ b/components/Element/ChatbotQuestions.vue
@@ -71,6 +71,7 @@ const loadQuestions = async () => {
   const endpoint = `${endpointBase}${addPath}?${query}`;
   const items = await useApiGetAll(endpoint);
   questions.value = items.data;
+  setTimeout(() => (isLoading.value = false), 750);
 };
 await loadQuestions();
 isQuestionAddAllowed.value = checkAddAllowed(questions);


### PR DESCRIPTION
Fixed an issue where adding or removing objects, such as Links, Documents, or Q&A, resulted in an infinite loading loop.