### PR TITLE
fix: textarea having white text when modifying chatbot

### DIFF
--- a/components/Form/Chatbot.vue
+++ b/components/Form/Chatbot.vue
@@ -10,7 +10,7 @@
       @keydown.enter.stop.prevent="save"
     />
 
-    <textarea class="textarea" v-model="description" :placeholder="$t('DESCRIPTION_PLACEHOLDER')" rows="4"></textarea>
+    <textarea v-model="description" :placeholder="$t('DESCRIPTION_PLACEHOLDER')" class="textarea" rows="4"></textarea>
 
     <div v-if="error" class="p-3 bg-neutral-100 text-center font-semibold text-brand_primary">
       {{ $t('AN_ERROR_OCCURRED_PLEASE_RETRY') }}

--- a/components/Form/Chatbot.vue
+++ b/components/Form/Chatbot.vue
@@ -37,6 +37,8 @@
 </template>
 
 <script lang="ts" setup>
+import type { collectionItem } from '~/store/states';
+
 const props = defineProps({
   isModal: {
     type: Boolean,
@@ -90,7 +92,7 @@ const create = async () => {
       },
     });
 
-    collection = data;
+    collection = data as collectionItem;
     statesStore.collection = collection;
 
     statesStore.menu.push({
@@ -108,8 +110,8 @@ const create = async () => {
 
 const update = async () => {
   try {
-    collection.cmetadata = {
-      ...collection.cmetadata,
+    collection!.cmetadata = {
+      ...collection!.cmetadata,
       ...{ title: title.value, description: description.value },
     };
 

--- a/components/Form/Chatbot.vue
+++ b/components/Form/Chatbot.vue
@@ -10,7 +10,7 @@
       @keydown.enter.stop.prevent="save"
     />
 
-    <textarea v-model="description" :placeholder="$t('DESCRIPTION_PLACEHOLDER')" rows="4"></textarea>
+    <textarea class="textarea" v-model="description" :placeholder="$t('DESCRIPTION_PLACEHOLDER')" rows="4"></textarea>
 
     <div v-if="error" class="p-3 bg-neutral-100 text-center font-semibold text-brand_primary">
       {{ $t('AN_ERROR_OCCURRED_PLEASE_RETRY') }}

--- a/components/Form/ChatbotQuestion.vue
+++ b/components/Form/ChatbotQuestion.vue
@@ -10,7 +10,7 @@
       @keydown.enter.stop.prevent="save"
     />
 
-    <textarea v-model="answer" :placeholder="$t('ANSWER_PLACEHOLDER')" rows="7"></textarea>
+    <textarea class="textarea" v-model="answer" :placeholder="$t('ANSWER_PLACEHOLDER')" rows="7"></textarea>
 
     <div v-if="error" class="p-3 bg-neutral-100 text-center font-semibold text-brand_primary">
       {{ $t('AN_ERROR_OCCURRED_PLEASE_RETRY') }}

--- a/components/Form/ChatbotQuestion.vue
+++ b/components/Form/ChatbotQuestion.vue
@@ -10,7 +10,7 @@
       @keydown.enter.stop.prevent="save"
     />
 
-    <textarea class="textarea" v-model="answer" :placeholder="$t('ANSWER_PLACEHOLDER')" rows="7"></textarea>
+    <textarea v-model="answer" :placeholder="$t('ANSWER_PLACEHOLDER')" class="textarea" rows="7"></textarea>
 
     <div v-if="error" class="p-3 bg-neutral-100 text-center font-semibold text-brand_primary">
       {{ $t('AN_ERROR_OCCURRED_PLEASE_RETRY') }}
@@ -115,7 +115,6 @@ const update = async () => {
 const deleteQuestion = async () => {
   isDeleting.value = true;
   try {
-    // @ts-ignore
     await $fetch(`/api/${integration}/index/${collectionUuid}/${props.item.custom_id}`, { method: 'DELETE' });
   } catch (err) {
     error.value = true;

--- a/components/Form/ChatbotQuestion.vue
+++ b/components/Form/ChatbotQuestion.vue
@@ -115,6 +115,7 @@ const update = async () => {
 const deleteQuestion = async () => {
   isDeleting.value = true;
   try {
+    // @ts-ignore
     await $fetch(`/api/${integration}/index/${collectionUuid}/${props.item.custom_id}`, { method: 'DELETE' });
   } catch (err) {
     error.value = true;

--- a/store/states.ts
+++ b/store/states.ts
@@ -16,11 +16,17 @@ export interface menuItem {
   edit: ItemEditLevel;
 }
 
+export interface collectionItem {
+  name: string,
+  uuid: string,
+  cmetadata: any,
+}
+
 export const useStatesStore = defineStore('states', {
   state: () => ({
     user: null as UserDataStore | null,
     menu: [] as menuItem[],
-    collection: null as object | null,
+    collection: null as collectionItem | null,
   }),
 
   actions: {

--- a/store/states.ts
+++ b/store/states.ts
@@ -17,9 +17,9 @@ export interface menuItem {
 }
 
 export interface collectionItem {
-  name: string,
-  uuid: string,
-  cmetadata: any,
+  name: string;
+  uuid: string;
+  cmetadata: any;
 }
 
 export const useStatesStore = defineStore('states', {


### PR DESCRIPTION
Aggiunge la classe `textarea` alle due textarea nel chatbot e nelle Q&A. 
Da capire come mai il selettore css non applica lo stile direttamente all'elemento `textarea`

Aggiunge anche un tipo `collectionItem` per evitare che TypeScript si arrabbi quando vengono assegnati i campi di collection tipo `cmetadata` e `title`
