### PR TITLE
Fix: files misalignment when name too long

### DIFF
--- a/components/Element/ChatbotFileItem.vue
+++ b/components/Element/ChatbotFileItem.vue
@@ -8,7 +8,7 @@
     }"
     @click.stop="download"
   >
-    <div class="flex space-x-3.5 items-center">
+    <div class="flex space-x-3.5 items-center break-words break-all">
       <div>
         <Icon name="ph:file-pdf-light" class="text-4xl" />
       </div>


### PR DESCRIPTION
Fixes a misalignment problem in files section when filename is too long.