### PR TITLE
Add custom features from JSON file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ node_modules
 .DS_Store
 .history
 .vscode
+
+feature_items.json

--- a/feature_items.json.sample
+++ b/feature_items.json.sample
@@ -1,27 +1,21 @@
 [
   {
-    "type" : "features",
-    "attributes" : {
-      "feature_type" : "analysis",
-      "uname" : "summary",
-      "title" : "Document Summary",
-      "description" : "Upload a PDF document, even one with many pages, to get a textual summary."
-    }
+    "feature_type": "analysis",
+    "uname": "summary",
+    "title": "Document Summary",
+    "description": "Upload a PDF document, even one with many pages, to get a textual summary."
   },
   {
-    "type" : "features",
-    "attributes" : {
-      "feature_type" : "analysis",
-      "uname" : "questionnaire",
-      "title" : "Questionnaire Generator",
-      "description" : "Upload a PDF or TXT file and get a questionnaire with multiple questions and answers on the text provided",
-      "feature_params": {
-        "service": "services.GenerateQuestionsService",
-        "accept": "application/pdf,text/plain",
-        "payload": {
-          "max_duration": 60,
-          "max_attempts": 3
-        }
+    "feature_type": "analysis",
+    "uname": "questionnaire",
+    "title": "Questionnaire Generator",
+    "description": "Upload a PDF or TXT file and get a questionnaire with multiple questions and answers on the text provided",
+    "feature_params": {
+      "service": "services.GenerateQuestionsService",
+      "accept": "application/pdf,text/plain",
+      "payload": {
+        "max_duration": 60,
+        "max_attempts": 3
       }
     }
   }

--- a/feature_items.json.sample
+++ b/feature_items.json.sample
@@ -1,21 +1,39 @@
 [
   {
-    "feature_type": "analysis",
+    "feature_type": "summary",
     "uname": "summary",
     "title": "Document Summary",
-    "description": "Upload a PDF document, even one with many pages, to get a textual summary."
+    "description": ""
+  },
+  {
+    "feature_type": "transcription",
+    "uname": "transcription",
+    "title": "Audio Transcription",
+    "description": ""
   },
   {
     "feature_type": "analysis",
-    "uname": "questionnaire",
-    "title": "Questionnaire Generator",
+    "uname": "questions_generator",
+    "title": "Questions Generator",
     "description": "Upload a PDF or TXT file and get a questionnaire with multiple questions and answers on the text provided",
     "feature_params": {
-      "service": "services.GenerateQuestionsService",
+      "service": "brevia.services.RefineTextAnalysisService",
       "accept": "application/pdf,text/plain",
       "payload": {
         "max_duration": 60,
         "max_attempts": 3
+      }
+    },
+    "prompts": {
+      "initial_prompt": {
+        "_type": "prompt",
+        "input_variables": ["text"],
+        "template": "Analyze the following text and generate 1-2 multiple choice questions, each with four options\n(A, B, C, D), of which only one is correct.\nHighlight the correct answer and make sure that the questions are relevant and understandable.\n\nReference text:\n-------------------\n{text}\n"
+      },
+      "refine_prompt": {
+        "_type": "prompt",
+        "input_variables": ["existing_answer", "text"],
+        "template": "You are given the following partial document containing a list of multiple choice questions:\nPartial Document:\n-------------------\n{existing_answer}\n-------------------\nRewrite the list of questions by adding 1-2 more questions at the bottom from the context provided below:\n\n-------------\n{text}\n-------------------"
       }
     }
   }

--- a/feature_items.json.sample
+++ b/feature_items.json.sample
@@ -1,0 +1,28 @@
+[
+  {
+    "type" : "features",
+    "attributes" : {
+      "feature_type" : "analysis",
+      "uname" : "summary",
+      "title" : "Document Summary",
+      "description" : "Upload a PDF document, even one with many pages, to get a textual summary."
+    }
+  },
+  {
+    "type" : "features",
+    "attributes" : {
+      "feature_type" : "analysis",
+      "uname" : "questionnaire",
+      "title" : "Questionnaire Generator",
+      "description" : "Upload a PDF or TXT file and get a questionnaire with multiple questions and answers on the text provided",
+      "feature_params": {
+        "service": "services.GenerateQuestionsService",
+        "accept": "application/pdf,text/plain",
+        "payload": {
+          "max_duration": 60,
+          "max_attempts": 3
+        }
+      }
+    }
+  }
+]

--- a/pages/analysis/[id].vue
+++ b/pages/analysis/[id].vue
@@ -68,7 +68,6 @@ const INTERVAL = 15000; // 15 seconds in ms
 const result = ref(null);
 const file = ref(null);
 const isBusy = ref(false);
-const summary = ref(null);
 const jobId = ref(null);
 const jobData = ref(null);
 const jobName = ref('');
@@ -81,6 +80,7 @@ const store = useStatesStore();
 const fileDrop = ref(null);
 
 const { $createPdf } = useNuxtApp();
+const { t } = useI18n();
 
 onBeforeRouteLeave(() => {
   stopPolling();
@@ -134,8 +134,8 @@ const elapsedTime = computed(() => {
 });
 
 const reset = () => {
+  result.value = null;
   file.value = null;
-  summary.value = null;
   error.value = '';
   isBusy.value = false;
   jobData.value = null;
@@ -214,9 +214,9 @@ const submit = async () => {
       store.setJobInfo(jobName.value, { id: jobId.value, file: { name: file.value?.name } });
       startPolling();
     }
-  } catch (error) {
-    error.value = error;
-    console.log(error);
+  } catch (err) {
+    error.value = t('AN_ERROR_OCCURRED_PLEASE_RETRY');
+    console.log(err);
   }
 };
 
@@ -248,9 +248,9 @@ const readJobData = async () => {
         updateJobsLeft();
       }
     }
-  } catch (error) {
-    error.value = error;
-    console.log(error);
+  } catch (err) {
+    error.value = t('AN_ERROR_OCCURRED_PLEASE_RETRY');
+    console.log(err);
   }
 };
 </script>

--- a/pages/summary/[id].vue
+++ b/pages/summary/[id].vue
@@ -13,7 +13,6 @@
             :accept-types="acceptTypes"
             @file-change="file = $event"
           />
-          />
         </div>
 
         <div v-if="menuItem?.params?.payload?.prompts" class="flex flex-col justify-center gap-6">

--- a/server/utils/menu-items.ts
+++ b/server/utils/menu-items.ts
@@ -1,4 +1,6 @@
 import { authorizationHeaders, apiUrl } from '~/server/utils/api-client';
+import fs from 'fs';
+import path from 'path';
 
 function chatbotItems(response): Array<any> {
   return response.map((item) => {
@@ -15,6 +17,12 @@ function chatbotItems(response): Array<any> {
 }
 
 function featureItems() {
+  const jsonFeatureItemsPath = path.resolve(process.cwd(), 'feature_items.json');
+  if (fs.existsSync(jsonFeatureItemsPath)) {
+    const fileContents = fs.readFileSync(jsonFeatureItemsPath, 'utf8');
+    return JSON.parse(fileContents);
+  }
+
   return [
     {
       type: 'features',

--- a/server/utils/menu-items.ts
+++ b/server/utils/menu-items.ts
@@ -20,7 +20,14 @@ function featureItems() {
   const jsonFeatureItemsPath = path.resolve(process.cwd(), 'feature_items.json');
   if (fs.existsSync(jsonFeatureItemsPath)) {
     const fileContents = fs.readFileSync(jsonFeatureItemsPath, 'utf8');
-    return JSON.parse(fileContents);
+    const featureItems = JSON.parse(fileContents);
+
+    return featureItems.map((item: any) => {
+      return {
+        type: 'features',
+        attributes: item,
+      };
+    });
   }
 
   return [


### PR DESCRIPTION
This PR introduces custom features, that can be defined via a `feature_items.json` JSON file.

A sample file is added in `feature_items.json.sample` - where an example of the 3 supported feature types (summary, analysis and transcription) is present.

These features will be available in the user dashboard instead of the default `Document Summary`
