### PR TITLE
Display API versions in footer

### DIFF
--- a/components/AppModal.vue
+++ b/components/AppModal.vue
@@ -15,6 +15,7 @@
         <LazyDialogShowFeedback v-if="$isOpenModal('ShowAnswerFeedback')" v-bind="modalStore.activeModalProps" />
         <LazyDialogChatDocuments v-if="$isOpenModal('ChatDocuments')" v-bind="modalStore.activeModalProps" @enlarge-window="largerModal = true" />
         <LazyDialogDocumentChunks v-if="$isOpenModal('SeeDocumentChunks')" v-bind="modalStore.activeModalProps" @enlarge-window="largerModal = true" />
+        <LazyDialogSystemInfo v-if="$isOpenModal('DialogSystemInfo')" v-bind="modalStore.activeModalProps" />
       </div>
     </div>
   </div>

--- a/components/Dialog/SystemInfo.vue
+++ b/components/Dialog/SystemInfo.vue
@@ -6,18 +6,24 @@
     </div>
 
     <div class="gap-3 tracking-wider">
-      <span class="col-span-3 justify-self-end whitespace-nowrap"> Brevia App <strong>v{{ appVersion }}</strong> </span>
+      <span class="col-span-3 justify-self-end whitespace-nowrap">
+        Brevia App <strong>v{{ appVersion }}</strong>
+      </span>
     </div>
 
     <hr class="border-t border-gray-300" />
 
     <div class="gap-3 tracking-wider">
       <template v-if="versions?.brevia">
-        <span class="col-span-3 justify-self-end whitespace-nowrap"> Brevia API <strong>v{{ versions.brevia }}</strong> </span>
+        <span class="col-span-3 justify-self-end whitespace-nowrap">
+          Brevia API <strong>v{{ versions.brevia }}</strong>
+        </span>
         <br />
       </template>
       <template v-if="versions?.apiName && versions?.apiVersion">
-        <span class="col-span-3 justify-self-end whitespace-nowrap"> {{ versions.apiName }} API <strong>v{{ versions.apiVersion }}</strong> </span>
+        <span class="col-span-3 justify-self-end whitespace-nowrap">
+          {{ versions.apiName }} API <strong>v{{ versions.apiVersion }}</strong>
+        </span>
         <br />
       </template>
       <span class="col-span-3 justify-self-end whitespace-nowrap">
@@ -29,11 +35,15 @@
 
     <div v-if="integration !== 'brevia'" class="gap-3 tracking-wider">
       <template v-if="integrationVersions?.get(integration)">
-        <span class="col-span-3 justify-self-end whitespace-nowrap"> {{ integrationName }} API <strong>v{{ integrationVersions?.get(integration) }}</strong> </span>
+        <span class="col-span-3 justify-self-end whitespace-nowrap">
+          {{ integrationName }} API <strong>v{{ integrationVersions?.get(integration) }}</strong>
+        </span>
         <br />
       </template>
       <template v-if="integrationVersions?.get('apiName') && integrationVersions?.get('apiVersion')">
-        <span class="col-span-3 justify-self-end whitespace-nowrap"> {{ integrationVersions?.get('apiName') }} API <strong>v{{ integrationVersions?.get('apiVersion') }}</strong> </span>
+        <span class="col-span-3 justify-self-end whitespace-nowrap">
+          {{ integrationVersions?.get('apiName') }} API <strong>v{{ integrationVersions?.get('apiVersion') }}</strong>
+        </span>
         <br />
       </template>
       <span class="col-span-3 justify-self-end whitespace-nowrap">

--- a/components/Dialog/SystemInfo.vue
+++ b/components/Dialog/SystemInfo.vue
@@ -1,0 +1,54 @@
+<template>
+  <div class="space-y-8 leading-tight">
+    <div class="flex justify-between items-center pb-4 mb-4 s\m:mb-5">
+      <h3 class="text-xl font-semibold text-gray-900">{{ $t('SYSTEM_INFO') }}</h3>
+      <Icon class="text-2xl hover:cursor-pointer hover:bg-sky-100" name="ph:x-bold" @click="$closeModal()" />
+    </div>
+
+    <div class="gap-3 tracking-wider">
+      <span class="col-span-3 justify-self-end whitespace-nowrap"> Brevia App <strong>v{{ appVersion }}</strong> </span>
+    </div>
+
+    <hr class="border-t border-gray-300" />
+
+    <div class="gap-3 tracking-wider">
+      <template v-if="versions?.brevia">
+        <span class="col-span-3 justify-self-end whitespace-nowrap"> Brevia API <strong>v{{ versions.brevia }}</strong> </span>
+        <br />
+      </template>
+      <template v-if="versions?.apiName && versions?.apiVersion">
+        <span class="col-span-3 justify-self-end whitespace-nowrap"> {{ versions.apiName }} API <strong>v{{ versions.apiVersion }}</strong> </span>
+        <br />
+      </template>
+      <span class="col-span-3 justify-self-end whitespace-nowrap">
+        API Base URL <strong>{{ versions.baseUrl }}</strong>
+      </span>
+    </div>
+
+    <hr v-if="integration !== 'brevia'" class="border-t border-gray-300" />
+
+    <div v-if="integration !== 'brevia'" class="gap-3 tracking-wider">
+      <template v-if="integrationVersions?.get(integration)">
+        <span class="col-span-3 justify-self-end whitespace-nowrap"> {{ integrationName }} API <strong>v{{ integrationVersions?.get(integration) }}</strong> </span>
+        <br />
+      </template>
+      <template v-if="integrationVersions?.get('apiName') && integrationVersions?.get('apiVersion')">
+        <span class="col-span-3 justify-self-end whitespace-nowrap"> {{ integrationVersions?.get('apiName') }} API <strong>v{{ integrationVersions?.get('apiVersion') }}</strong> </span>
+        <br />
+      </template>
+      <span class="col-span-3 justify-self-end whitespace-nowrap">
+        API Base URL <strong>{{ integrationVersions?.get('baseUrl') }}</strong>
+      </span>
+    </div>
+  </div>
+</template>
+
+<script lang="ts" setup>
+const appVersion = useRuntimeConfig().public.version;
+const response = await fetch('/api/brevia/versions');
+const versions = await response.json();
+
+const integration = useIntegration();
+const integrationName = integration.charAt(0).toUpperCase() + integration.slice(1);
+const integrationVersions = await useIntegrationVersion();
+</script>

--- a/components/Main/Footer.vue
+++ b/components/Main/Footer.vue
@@ -33,9 +33,9 @@
 
     <div class="flex gap-3 text-xs tracking-wider text-white">
       <span class="col-span-3 justify-self-end whitespace-nowrap"> Brevia App: {{ appVersion }} </span>
-      <span v-if="data?.brevia" class="col-span-3 justify-self-end whitespace-nowrap"> Brevia API: {{ data.brevia }} </span>
-      <span v-if="data?.apiName && data?.apiVersion" class="col-span-3 justify-self-end whitespace-nowrap">
-        {{ data?.apiName }} API: {{ data?.apiVersion }}
+      <span v-if="versions?.brevia" class="col-span-3 justify-self-end whitespace-nowrap"> Brevia API: {{ versions.brevia }} </span>
+      <span v-if="versions?.apiName && versions?.apiVersion" class="col-span-3 justify-self-end whitespace-nowrap">
+        {{ versions?.apiName }} API: {{ versions?.apiVersion }}
       </span>
     </div>
   </footer>
@@ -46,5 +46,5 @@ const cookiesPrivacyTerms = useRuntimeConfig().public.cookiesPrivacyTerms !== ''
 const appVersion = useRuntimeConfig().public.version;
 
 const response = await fetch('/api/brevia/versions');
-const data = await response.json();
+const versions = await response.json();
 </script>

--- a/components/Main/Footer.vue
+++ b/components/Main/Footer.vue
@@ -33,10 +33,10 @@
 
     <div class="flex gap-3 text-xs tracking-wider text-white">
       <span v-if="statesStore.userHasRole('admin')" class="col-span-3 justify-self-end whitespace-nowrap">
-        <NuxtLink to="#" @click="$openModal('DialogSystemInfo')">
+        <button @click="$openModal('DialogSystemInfo')">
           {{ appVersion }}
           <Icon name="ph:info-bold" />
-        </NuxtLink>
+        </button>
       </span>
       <span v-else class="col-span-3 justify-self-end whitespace-nowrap"> v{{ appVersion }} </span>
     </div>

--- a/components/Main/Footer.vue
+++ b/components/Main/Footer.vue
@@ -38,6 +38,13 @@
         {{ versions?.apiName }} API: {{ versions?.apiVersion }}
       </span>
     </div>
+
+    <div v-if="integration !== 'brevia'" class="flex gap-3 text-xs tracking-wider text-white">
+      <span v-if="integrationVersions?.get(integration)" class="col-span-3 justify-self-end whitespace-nowrap"> {{ integration }} API: {{ integrationVersions?.get(integration) }} </span>
+      <span v-if="integrationVersions?.get('apiName') && integrationVersions?.get('apiVersion')" class="col-span-3 justify-self-end whitespace-nowrap">
+        {{ integrationVersions?.get('apiName') }} API: {{ integrationVersions?.get('apiVersion') }}
+      </span>
+    </div>
   </footer>
 </template>
 <script setup lang="ts">
@@ -47,4 +54,7 @@ const appVersion = useRuntimeConfig().public.version;
 
 const response = await fetch('/api/brevia/versions');
 const versions = await response.json();
+
+const integration = useIntegration();
+const integrationVersions = await useIntegrationVersion();
 </script>

--- a/components/Main/Footer.vue
+++ b/components/Main/Footer.vue
@@ -33,7 +33,7 @@
 
     <div class="flex gap-3 text-xs tracking-wider text-white">
       <span v-if="statesStore.userHasRole('admin')" class="col-span-3 justify-self-end whitespace-nowrap">
-        <NuxtLink @click="$openModal('DialogSystemInfo')" to="#">
+        <NuxtLink to="#" @click="$openModal('DialogSystemInfo')">
           {{ appVersion }}
           <Icon name="ph:info-bold" />
         </NuxtLink>

--- a/components/Main/Footer.vue
+++ b/components/Main/Footer.vue
@@ -32,12 +32,17 @@
     </div>
 
     <div class="flex gap-3 text-xs tracking-wider text-white">
-      <span class="col-span-3 justify-self-end whitespace-nowrap"> v{{ version }} </span>
+      <span class="col-span-3 justify-self-end whitespace-nowrap"> Brevia App: {{ appVersion }} </span>
+      <span v-if="data?.brevia" class="col-span-3 justify-self-end whitespace-nowrap"> Brevia API: {{ data.brevia }} </span>
+      <span v-if="data?.apiName && data?.apiVersion" class="col-span-3 justify-self-end whitespace-nowrap"> {{ data?.apiName }} API: {{ data?.apiVersion }} </span>
     </div>
   </footer>
 </template>
 <script setup lang="ts">
 const cookiesPrivacyTerms = useRuntimeConfig().public.cookiesPrivacyTerms !== '';
 
-const version = useRuntimeConfig().public.version;
+const appVersion = useRuntimeConfig().public.version;
+
+const response = await fetch('/api/brevia/versions');
+const data = await response.json();
 </script>

--- a/components/Main/Footer.vue
+++ b/components/Main/Footer.vue
@@ -32,29 +32,18 @@
     </div>
 
     <div class="flex gap-3 text-xs tracking-wider text-white">
-      <span class="col-span-3 justify-self-end whitespace-nowrap"> Brevia App: {{ appVersion }} </span>
-      <span v-if="versions?.brevia" class="col-span-3 justify-self-end whitespace-nowrap"> Brevia API: {{ versions.brevia }} </span>
-      <span v-if="versions?.apiName && versions?.apiVersion" class="col-span-3 justify-self-end whitespace-nowrap">
-        {{ versions?.apiName }} API: {{ versions?.apiVersion }}
+      <span v-if="statesStore.userHasRole('admin')" class="col-span-3 justify-self-end whitespace-nowrap">
+        <NuxtLink @click="$openModal('DialogSystemInfo')" to="#">
+          {{ appVersion }}
+          <Icon name="ph:info-bold" />
+        </NuxtLink>
       </span>
-    </div>
-
-    <div v-if="integration !== 'brevia'" class="flex gap-3 text-xs tracking-wider text-white">
-      <span v-if="integrationVersions?.get(integration)" class="col-span-3 justify-self-end whitespace-nowrap"> {{ integration }} API: {{ integrationVersions?.get(integration) }} </span>
-      <span v-if="integrationVersions?.get('apiName') && integrationVersions?.get('apiVersion')" class="col-span-3 justify-self-end whitespace-nowrap">
-        {{ integrationVersions?.get('apiName') }} API: {{ integrationVersions?.get('apiVersion') }}
-      </span>
+      <span v-else class="col-span-3 justify-self-end whitespace-nowrap"> v{{ appVersion }} </span>
     </div>
   </footer>
 </template>
 <script setup lang="ts">
 const cookiesPrivacyTerms = useRuntimeConfig().public.cookiesPrivacyTerms !== '';
-
 const appVersion = useRuntimeConfig().public.version;
-
-const response = await fetch('/api/brevia/versions');
-const versions = await response.json();
-
-const integration = useIntegration();
-const integrationVersions = await useIntegrationVersion();
+const statesStore = useStatesStore();
 </script>

--- a/components/Main/Footer.vue
+++ b/components/Main/Footer.vue
@@ -34,7 +34,9 @@
     <div class="flex gap-3 text-xs tracking-wider text-white">
       <span class="col-span-3 justify-self-end whitespace-nowrap"> Brevia App: {{ appVersion }} </span>
       <span v-if="data?.brevia" class="col-span-3 justify-self-end whitespace-nowrap"> Brevia API: {{ data.brevia }} </span>
-      <span v-if="data?.apiName && data?.apiVersion" class="col-span-3 justify-self-end whitespace-nowrap"> {{ data?.apiName }} API: {{ data?.apiVersion }} </span>
+      <span v-if="data?.apiName && data?.apiVersion" class="col-span-3 justify-self-end whitespace-nowrap">
+        {{ data?.apiName }} API: {{ data?.apiVersion }}
+      </span>
     </div>
   </footer>
 </template>

--- a/composables/integration-version.ts
+++ b/composables/integration-version.ts
@@ -1,0 +1,9 @@
+export const useIntegrationVersion = async (): Promise<Map<String, String>> => {
+  const integration = useIntegration();
+  if (integration === 'brevia') {
+    return new Map();
+  }
+  const response: any = await $fetch(`/api/${integration}/versions`);
+
+  return new Map(Object.entries(response));
+};

--- a/composables/integration-version.ts
+++ b/composables/integration-version.ts
@@ -1,4 +1,4 @@
-export const useIntegrationVersion = async (): Promise<Map<String, String>> => {
+export const useIntegrationVersion = async (): Promise<Map<string, string>> => {
   const integration = useIntegration();
   if (integration === 'brevia') {
     return new Map();

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -152,6 +152,7 @@
     "START_DATE": "Start date",
     "SUCCESS": "Success",
     "SUMMARIZATION": "summarization",
+    "SYSTEM_INFO": "System info",
     "TERMS_AND_CONDITIONS": "Terms & Conditions",
     "TERMS_OF_SERVICE": "Terms of Service",
     "TEXT_SUMMARY": "Text summary",

--- a/locales/it/messages.json
+++ b/locales/it/messages.json
@@ -152,6 +152,7 @@
     "START_DATE": "Data iniziale",
     "SUCCESS": "Ok",
     "SUMMARIZATION": "Creazione sommario",
+    "SYSTEM_INFO": "Informazioni di sistema",
     "TERMS_AND_CONDITIONS": "Termini e Condizioni",
     "TERMS_OF_SERVICE": "Termini di servizio",
     "TEXT_SUMMARY": "Riassunto",

--- a/modules/bedita/index.ts
+++ b/modules/bedita/index.ts
@@ -106,6 +106,10 @@ export default defineNuxtModule<ModuleOptions>({
           './runtime/server/api/bedita/index/[collection_id]/[document_id].delete',
         ),
       },
+      {
+        route: '/api/bedita/versions',
+        handler: resolver.resolve('./runtime/server/api/bedita/versions.get'),
+      },
     ];
 
     endpointsEnabled.forEach((endpoint) => {

--- a/modules/bedita/runtime/server/api/bedita/versions.get.ts
+++ b/modules/bedita/runtime/server/api/bedita/versions.get.ts
@@ -7,6 +7,7 @@ export default defineEventHandler(async (event) => {
       bedita: response.headers.get('X-BEdita-Version'),
       apiName: response.headers.get('X-API-Name'),
       apiVersion: response.headers.get('X-API-Version'),
+      baseUrl: useRuntimeConfig().bedita.apiBaseUrl,
     };
   } catch (error) {
     return handleBeditaApiError(event, error);

--- a/modules/bedita/runtime/server/api/bedita/versions.get.ts
+++ b/modules/bedita/runtime/server/api/bedita/versions.get.ts
@@ -1,0 +1,14 @@
+export default defineEventHandler(async (event) => {
+  try {
+    const client = await beditaApiClient(event);
+    const response = await client.get('/home');
+
+    return {
+      bedita: response.headers.get('X-BEdita-Version'),
+      apiName: response.headers.get('X-API-Name'),
+      apiVersion: response.headers.get('X-API-Version'),
+    };
+  } catch (error) {
+    return handleBeditaApiError(event, error);
+  }
+});

--- a/server/api/brevia/versions.get.ts
+++ b/server/api/brevia/versions.get.ts
@@ -9,6 +9,7 @@ export default defineEventHandler(async (event) => {
       brevia: response.headers.get('X-Brevia-Version'),
       apiName: response.headers.get('X-API-Name'),
       apiVersion: response.headers.get('X-API-Version'),
+      baseUrl: useRuntimeConfig().apiBaseUrl,
     };
   } catch (error) {
     return handleApiError(event, error);

--- a/server/api/brevia/versions.get.ts
+++ b/server/api/brevia/versions.get.ts
@@ -6,10 +6,10 @@ export default defineEventHandler(async (event) => {
     });
 
     return {
-      'brevia': response.headers.get('X-Brevia-Version'),
-      'apiName': response.headers.get('X-API-Name'),
-      'apiVersion': response.headers.get('X-API-Version'),
-    }
+      brevia: response.headers.get('X-Brevia-Version'),
+      apiName: response.headers.get('X-API-Name'),
+      apiVersion: response.headers.get('X-API-Version'),
+    };
   } catch (error) {
     return handleApiError(event, error);
   }

--- a/server/api/brevia/versions.get.ts
+++ b/server/api/brevia/versions.get.ts
@@ -1,0 +1,16 @@
+export default defineEventHandler(async (event) => {
+  try {
+    const response: Response = await fetch(apiUrl('/status'), {
+      method: 'HEAD',
+      headers: authorizationHeaders(),
+    });
+
+    return {
+      'brevia': response.headers.get('X-Brevia-Version'),
+      'apiName': response.headers.get('X-API-Name'),
+      'apiVersion': response.headers.get('X-API-Version'),
+    }
+  } catch (error) {
+    return handleApiError(event, error);
+  }
+});


### PR DESCRIPTION
This PR adds some version and system information to a new modal, available for `admin` users.
Information displayed is:
 * Brevia API version
 * custom Brevia API name and version
 * API Base URL
 
If an integration is active the same information for the integration API will be displayed as well 