### PR TITLE
Remove `link_load_options` logic

### DIFF
--- a/components/Dialog/EditMetadata.vue
+++ b/components/Dialog/EditMetadata.vue
@@ -39,13 +39,6 @@
             </VueDatePicker>
           </slot>
 
-          <slot v-if="isSimpleString(meta)">
-            <label class="flex flex-col items-start space-y-2">
-              <span>{{ name }}</span>
-            </label>
-            <input id="item_{{ index}}" v-model="metadata[name]" type="text" name="item_{{ index}}" />
-          </slot>
-
           <slot v-if="isCheckbox(meta)">
             <label class="flex flex-row items-center space-x-2">
               <span>{{ name }}</span>
@@ -114,10 +107,6 @@ const isSelect = (prop: any) => {
 
 const isDate = (prop: any) => {
   return prop?.type == 'string' && prop?.format == 'date';
-};
-
-const isSimpleString = (prop: any) => {
-  return prop?.type == 'string' && !prop?.format && !prop?.enum;
 };
 
 const isCheckbox = (prop: any) => {

--- a/components/Dialog/EditMetadata.vue
+++ b/components/Dialog/EditMetadata.vue
@@ -39,6 +39,13 @@
             </VueDatePicker>
           </slot>
 
+          <slot v-if="isSimpleString(meta)">
+            <label class="flex flex-col items-start space-y-2">
+              <span>{{ name }}</span>
+            </label>
+            <input id="item_{{ index}}" v-model="metadata[name]" type="text" name="item_{{ index}}" />
+          </slot>
+
           <slot v-if="isCheckbox(meta)">
             <label class="flex flex-row items-center space-x-2">
               <span>{{ name }}</span>
@@ -107,6 +114,10 @@ const isSelect = (prop: any) => {
 
 const isDate = (prop: any) => {
   return prop?.type == 'string' && prop?.format == 'date';
+};
+
+const isSimpleString = (prop: any) => {
+  return prop?.type == 'string' && !prop?.format && !prop?.enum;
 };
 
 const isCheckbox = (prop: any) => {

--- a/components/Form/ChatbotLink.vue
+++ b/components/Form/ChatbotLink.vue
@@ -79,7 +79,6 @@ if (props.item.cmetadata) {
 const statesStore = useStatesStore();
 const collectionUuid = statesStore.collection?.uuid || '';
 const metadataDefaults = statesStore.collection?.cmetadata?.metadata_defaults?.links || {};
-const linkLoadOptions = statesStore.collection?.cmetadata?.link_load_options || [];
 const integration = useIntegration();
 const indexingResult = ref<'Indexed' | 'Not Indexed' | 'None'>('None');
 
@@ -138,39 +137,12 @@ const create = async () => {
         link: url.value,
         collection_id: collectionUuid,
         metadata: { ...metadata, ...metadataDefaults },
-        options: linkOptions(url.value),
       },
     });
   } catch (err) {
     console.log(err);
     error.value = true;
   }
-};
-
-const linkOptions = (url: string): Record<string, any> => {
-  const uniqueKeys = new Set<string>();
-  linkLoadOptions.forEach((option: any) => {
-    Object.keys(option).forEach((key) => {
-      if (key !== 'url') {
-        uniqueKeys.add(key);
-      }
-    });
-  });
-
-  const options: Record<string, any> = {};
-  uniqueKeys.forEach((key) => {
-    options[key] = linkOptionsProperty(url, key);
-  });
-
-  return options;
-};
-
-const linkOptionsProperty = (url: string, property: string) => {
-  const option = linkLoadOptions.find((o: any) => o.url === url)?.[property];
-  if (option) {
-    return option;
-  }
-  return linkLoadOptions.find((o: any) => url.startsWith(o.url))?.[property];
 };
 
 const deleteLink = async () => {
@@ -199,7 +171,6 @@ const reindexLink = async (item: Record<string, any>, collection: string | undef
         link: url,
         collection_id: collection,
         metadata: metadata,
-        options: linkOptions(url),
         document_id: document_id,
       },
     });

--- a/components/Form/ChatbotLink.vue
+++ b/components/Form/ChatbotLink.vue
@@ -148,13 +148,18 @@ const create = async () => {
 };
 
 const linkOptions = (url: string) => {
-  let selector: any = linkLoadOptions.find((o: any) => o.url === url)?.selector;
-  if (selector) {
-    return { selector };
-  }
-  selector = linkLoadOptions.find((o: any) => url.startsWith(o.url))?.selector;
+  return {
+    selector: linkOptionsProperty(url, 'selector'),
+    callback: linkOptionsProperty(url, 'callback'),
+  };
+};
 
-  return selector ? { selector } : {};
+const linkOptionsProperty = (url: string, property: string) => {
+  const option = linkLoadOptions.find((o: any) => o.url === url)?.[property];
+  if (option) {
+    return option;
+  }
+  return linkLoadOptions.find((o: any) => url.startsWith(o.url))?.[property];
 };
 
 const deleteLink = async () => {

--- a/components/Form/ChatbotLink.vue
+++ b/components/Form/ChatbotLink.vue
@@ -147,11 +147,22 @@ const create = async () => {
   }
 };
 
-const linkOptions = (url: string) => {
-  return {
-    selector: linkOptionsProperty(url, 'selector'),
-    callback: linkOptionsProperty(url, 'callback'),
-  };
+const linkOptions = (url: string): Record<string, any> => {
+  const uniqueKeys = new Set<string>();
+  linkLoadOptions.forEach((option: any) => {
+    Object.keys(option).forEach((key) => {
+      if (key !== 'url') {
+        uniqueKeys.add(key);
+      }
+    });
+  });
+
+  const options: Record<string, any> = {};
+  uniqueKeys.forEach((key) => {
+    options[key] = linkOptionsProperty(url, key);
+  });
+
+  return options;
 };
 
 const linkOptionsProperty = (url: string, property: string) => {


### PR DESCRIPTION
This PR removes `link_load_options` logic from `Form/ChatbotLink.vue`: logic is correctly implemented in `Brevia` from version `0.2.2`
