### PR TITLE
Load `nuxt-bedita` module only if integration requested

### DIFF
--- a/modules/bedita/index.ts
+++ b/modules/bedita/index.ts
@@ -3,6 +3,7 @@ import {
   addServerHandler,
   addImportsDir,
   createResolver,
+  installModule,
   addServerImportsDir,
   logger,
 } from '@nuxt/kit';
@@ -38,10 +39,17 @@ export default defineNuxtModule<ModuleOptions>({
     },
   },
 
-  setup(options, nuxt) {
+  async setup(options, nuxt) {
+    const runtimeConfig = nuxt.options.runtimeConfig;
+    const integration = process.env.NUXT_PUBLIC_INTEGRATION || runtimeConfig.public.integration;
+    if (integration !== 'bedita') {
+      logger.info('Skipping bedita integration setup');
+      return;
+    }
     logger.start('Setting up bedita integration...');
 
-    const runtimeConfig = nuxt.options.runtimeConfig;
+    await installModule('@atlasconsulting/nuxt-bedita');
+
     runtimeConfig.public.bedita = defu(runtimeConfig.public.bedita || {}, {
       features: options.features,
     });

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -54,7 +54,6 @@ export default defineNuxtConfig({
     '@nuxtjs/i18n',
     'nuxt-icon',
     'nuxt-gtag',
-    '@atlasconsulting/nuxt-bedita',
     '@nuxt/eslint',
   ],
   build: {


### PR DESCRIPTION
This PR introduces conditional loading for `nuxt-bedita` module inside internal BEdita integration module (currently in `./modules/bedita`) 
If integration is not requested via env vars module setup is skipped and `nuxt-bedita` module is not loaded
